### PR TITLE
test/database.py: Remove int-convert in connect_mysql() 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -109,6 +109,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           python -m pip install pytest-playwright
+          python -m pip install PyMySQL
+          python -m pip install python-dotenv
           # pip install -r requirements.txt
       - name: Ensure browsers are installed
         run: python -m playwright install --with-deps

--- a/source/test/database.py
+++ b/source/test/database.py
@@ -13,7 +13,7 @@ def connect_mysql():
         'user': os.getenv('DB_USER'),
         'passwd': os.getenv('DB_PASSWD'),
         'host': os.getenv('DB_HOST'),
-        'port': int(os.getenv('DB_PORT')),
+        'port': os.getenv('DB_PORT'),
         'db': os.getenv('DB_NAME')
     }
     


### PR DESCRIPTION
Force int-convertion removed. Convert isn't necessary and makes error.
But I can't connect to mySQL through GitHub Actions. Maybe you guys can try again.